### PR TITLE
#118 Make Retries More Robust

### DIFF
--- a/frontend/src/components/app/SearchResultsList.tsx
+++ b/frontend/src/components/app/SearchResultsList.tsx
@@ -43,7 +43,7 @@ export default function SearchResultsList() {
     useEffect(() => {
         if (searchResults.length > 0) {
             // Check if we have any non-terminal cases to poll
-            const terminalStates = ['complete', 'notFound', 'failed'];
+            const terminalStates = ['complete', 'failed'];
             const hasNonTerminalCases = searchResults.some(result => {
                 const status = result.zipCase.fetchStatus.status;
                 return !terminalStates.includes(status);

--- a/frontend/src/components/app/SearchStatus.tsx
+++ b/frontend/src/components/app/SearchStatus.tsx
@@ -18,6 +18,7 @@ const renderStatusIcon = (icon: React.ReactNode) => {
 const renderSearchStatus = (status: FetchStatus) => {
     switch (status.status) {
         case 'processing':
+        case 'reprocessing':
             return renderStatusIcon(
                 <div title="processing" aria-label="processing">
                     <Puff height="100%" width="100%" color="#4fa94d" ariaLabel="puff-loading" />

--- a/frontend/src/components/app/__tests__/SearchResultsList.test.tsx
+++ b/frontend/src/components/app/__tests__/SearchResultsList.test.tsx
@@ -163,13 +163,14 @@ describe('SearchResultsList', () => {
         const mockResults = {
             case1: createSearchResult('case1', 'complete'), // terminal
             case2: createSearchResult('case2', 'processing'), // non-terminal
+            case3: createSearchResult('case3', 'notFound'), // non-terminal (should retry)
         };
 
         // Mock the hook to return a mix of terminal and non-terminal cases
         vi.mocked(hooks.useSearchResults).mockReturnValue({
             data: {
                 results: mockResults,
-                searchBatches: [['case1', 'case2']],
+                searchBatches: [['case1', 'case2', 'case3']],
             },
             isLoading: false,
             isError: false,
@@ -192,15 +193,14 @@ describe('SearchResultsList', () => {
 
         const mockResults = {
             case1: createSearchResult('case1', 'complete'),
-            case2: createSearchResult('case2', 'notFound'),
-            case3: createSearchResult('case3', 'failed'),
+            case2: createSearchResult('case2', 'failed'),
         };
 
         // Mock the hook to return only terminal cases
         vi.mocked(hooks.useSearchResults).mockReturnValue({
             data: {
                 results: mockResults,
-                searchBatches: [['case1', 'case2', 'case3']],
+                searchBatches: [['case1', 'case2']],
             },
             isLoading: false,
             isError: false,

--- a/frontend/src/components/app/__tests__/SearchStatus.test.tsx
+++ b/frontend/src/components/app/__tests__/SearchStatus.test.tsx
@@ -22,6 +22,13 @@ describe('SearchStatus component', () => {
         expect(screen.getByLabelText('processing')).toBeInTheDocument();
     });
 
+    it('renders reprocessing status with spinner like processing', () => {
+        render(<SearchStatus status={createStatus('reprocessing')} />);
+
+        expect(screen.getByTestId('loader-spinner')).toBeInTheDocument();
+        expect(screen.getByLabelText('processing')).toBeInTheDocument();
+    });
+
     it('renders queued status with clock icon', () => {
         render(<SearchStatus status={createStatus('queued')} />);
 

--- a/frontend/src/hooks/useCaseSearch.ts
+++ b/frontend/src/hooks/useCaseSearch.ts
@@ -111,7 +111,7 @@ export function useConsolidatedPolling() {
             return [];
         }
 
-        const terminalStates = ['complete', 'notFound', 'failed'];
+        const terminalStates = ['complete', 'failed'];
 
         return Object.values(state.results)
             .filter(result => {

--- a/serverless/lib/CaseSearchProcessor.ts
+++ b/serverless/lib/CaseSearchProcessor.ts
@@ -53,10 +53,6 @@ export async function processCaseSearchRequest(req: CaseSearchRequest): Promise<
                 const caseSummary = results[caseNumber].caseSummary;
 
                 switch (status) {
-                    case 'processing':
-                        // Processing cases should be left alone - don't re-queue
-                        console.log(`Case ${caseNumber} already has status ${status}, preserving`);
-                        continue;
                     case 'complete':
                         if (caseSummary) {
                             // Truly complete - has both ID and summary
@@ -114,6 +110,9 @@ export async function processCaseSearchRequest(req: CaseSearchRequest): Promise<
                     case 'notFound':
                     case 'failed':
                     case 'queued':
+                    case 'processing':
+                        // We requeue 'queued' and 'processing' because they might be stuck.
+                        // When they get picked up from the queue, we'll see whether they became 'complete' in the mean time and exit early.
                         casesToQueue.push(caseNumber);
                 }
             } else {

--- a/serverless/lib/CaseSearchProcessor.ts
+++ b/serverless/lib/CaseSearchProcessor.ts
@@ -93,6 +93,7 @@ export async function processCaseSearchRequest(req: CaseSearchRequest): Promise<
                         }
                         break;
                     case 'found':
+                    case 'reprocessing':
                         console.log(`Case ${caseNumber} already has status ${status}, preserving`);
 
                         // Queue for data retrieval if we have caseId
@@ -105,7 +106,7 @@ export async function processCaseSearchRequest(req: CaseSearchRequest): Promise<
                             }
                             continue;
                         } else {
-                            // 'found' cases without caseId should be re-queued for search
+                            // 'found' or 'reprocessing' cases without caseId should be re-queued for search
                             console.log(`Case ${caseNumber} has '${status}' status but missing caseId, re-queueing for search`);
                             casesToQueue.push(caseNumber);
                         }

--- a/serverless/lib/StorageClient.ts
+++ b/serverless/lib/StorageClient.ts
@@ -4,6 +4,7 @@ import {
     DynamoDBDocumentClient,
     GetCommand,
     PutCommand,
+    DeleteCommand as DynamoDBDeleteCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { KMSClient, EncryptCommand, DecryptCommand } from '@aws-sdk/client-kms';
 import {
@@ -228,6 +229,225 @@ async function encryptValue(value: string): Promise<string> {
 async function decryptValue(encryptedValue: string): Promise<string> {
     const result = await kms.send(new DecryptCommand({ CiphertextBlob: Buffer.from(encryptedValue, 'base64') }));
     return Buffer.from(result.Plaintext!).toString();
+}
+
+/**
+ * Validates and processes a case summary, handling corruption detection and cleanup
+ * @param caseNumber - The case number being processed
+ * @param caseData - The case data from DynamoDB
+ * @param summaryItem - The raw summary item from DynamoDB (may be undefined)
+ * @returns The validated summary or undefined if corrupted/invalid
+ */
+export async function validateAndProcessCaseSummary(
+    caseNumber: string,
+    caseData: ZipCase,
+    summaryItem: Record<string, unknown> | undefined
+): Promise<CaseSummary | undefined> {
+    let summary: CaseSummary | undefined = undefined;
+
+    try {
+        // Attempt to parse the summary data
+        if (summaryItem) {
+            summary = summaryItem as unknown as CaseSummary;
+
+            // Validate that the summary has the required structure
+            if (summary && typeof summary === 'object') {
+                if (!summary.caseName || !summary.court || !Array.isArray(summary.charges)) {
+                    console.warn(`Corrupted summary detected for case ${caseNumber}, will be cleaned up`);
+                    summary = undefined;
+
+                    // Mark this case for cleanup in the background with single retry
+                    setImmediate(async () => {
+                        try {
+                            // Check if this is already a reprocessing attempt
+                            const isReprocessing = caseData.fetchStatus.status === 'reprocessing';
+                            const tryCount = isReprocessing && 'tryCount' in caseData.fetchStatus ? caseData.fetchStatus.tryCount : 0;
+
+                            if (tryCount >= 1) {
+                                // Already tried reprocessing once, mark as permanently failed
+                                console.error(
+                                    `Case ${caseNumber} still corrupted after reprocessing attempt, marking as permanently failed`
+                                );
+
+                                // Raise alert for persistent corruption
+                                const AlertService = await import('./AlertService');
+                                await AlertService.default.logError(
+                                    AlertService.Severity.ERROR,
+                                    AlertService.AlertCategory.DATABASE,
+                                    'Persistent case summary corruption detected',
+                                    new Error(
+                                        `Case ${caseNumber} has corrupted summary data that persists after reprocessing. Summary validation failed: missing required fields (caseName: ${!!summary?.caseName}, court: ${!!summary?.court}, charges array: ${Array.isArray(summary?.charges)})`
+                                    ),
+                                    {
+                                        caseNumber,
+                                        caseId: caseData.caseId,
+                                        tryCount,
+                                        summaryFields: {
+                                            hasCaseName: !!summary?.caseName,
+                                            hasCourt: !!summary?.court,
+                                            hasChargesArray: Array.isArray(summary?.charges),
+                                            chargesLength: Array.isArray(summary?.charges) ? summary.charges.length : 'N/A',
+                                        },
+                                    }
+                                );
+
+                                // Mark as permanently failed
+                                await StorageClient.saveCase({
+                                    ...caseData,
+                                    fetchStatus: {
+                                        status: 'failed',
+                                        message: 'Persistent data corruption detected after reprocessing attempt',
+                                    },
+                                    lastUpdated: new Date().toISOString(),
+                                });
+                                return;
+                            }
+
+                            console.log(`Cleaning up corrupted summary for ${caseNumber} and marking for reprocessing`);
+
+                            // Raise alert for initial corruption detection
+                            const AlertService = await import('./AlertService');
+                            await AlertService.default.logError(
+                                AlertService.Severity.WARNING,
+                                AlertService.AlertCategory.DATABASE,
+                                'Case summary corruption detected, attempting reprocessing',
+                                new Error(
+                                    `Case ${caseNumber} has corrupted summary data. Summary validation failed: missing required fields (caseName: ${!!summary?.caseName}, court: ${!!summary?.court}, charges array: ${Array.isArray(summary?.charges)})`
+                                ),
+                                {
+                                    caseNumber,
+                                    caseId: caseData.caseId,
+                                    action: 'reprocessing',
+                                    summaryFields: {
+                                        hasCaseName: !!summary?.caseName,
+                                        hasCourt: !!summary?.court,
+                                        hasChargesArray: Array.isArray(summary?.charges),
+                                        chargesLength: Array.isArray(summary?.charges) ? summary.charges.length : 'N/A',
+                                    },
+                                }
+                            );
+
+                            // Delete the corrupted summary
+                            await StorageClient.deleteCaseSummary(caseNumber);
+
+                            // Update case status to 'reprocessing' to trigger immediate reprocessing
+                            if (caseData.caseId) {
+                                await StorageClient.saveCase({
+                                    ...caseData,
+                                    fetchStatus: { status: 'reprocessing', tryCount: tryCount + 1 },
+                                    lastUpdated: new Date().toISOString(),
+                                });
+
+                                console.log(`Case ${caseNumber} marked for reprocessing due to corrupted summary`);
+                            }
+                        } catch (cleanupError) {
+                            console.error(`Failed to cleanup corrupted summary for case ${caseNumber}:`, cleanupError);
+
+                            // Alert on cleanup failure too
+                            try {
+                                const AlertService = await import('./AlertService');
+                                await AlertService.default.logError(
+                                    AlertService.Severity.ERROR,
+                                    AlertService.AlertCategory.SYSTEM,
+                                    'Failed to cleanup corrupted case summary',
+                                    cleanupError instanceof Error ? cleanupError : new Error(String(cleanupError)),
+                                    { caseNumber, caseId: caseData.caseId }
+                                );
+                            } catch (alertError) {
+                                console.error('Failed to send cleanup failure alert:', alertError);
+                            }
+                        }
+                    });
+                }
+            }
+        }
+    } catch (error) {
+        console.error(`Error processing summary for case ${caseNumber}:`, error);
+        summary = undefined;
+
+        // Also trigger cleanup for parsing errors with single retry
+        setImmediate(async () => {
+            try {
+                // Check if this is already a reprocessing attempt
+                const isReprocessing = caseData.fetchStatus.status === 'reprocessing';
+                const tryCount = isReprocessing && 'tryCount' in caseData.fetchStatus ? caseData.fetchStatus.tryCount : 0;
+
+                if (tryCount >= 1) {
+                    console.error(`Case ${caseNumber} parsing errors persist after reprocessing, marking as permanently failed`);
+
+                    // Raise alert for persistent parsing failure
+                    const AlertService = await import('./AlertService');
+                    await AlertService.default.logError(
+                        AlertService.Severity.ERROR,
+                        AlertService.AlertCategory.DATABASE,
+                        'Persistent case summary parsing failure',
+                        error instanceof Error ? error : new Error(String(error)),
+                        {
+                            caseNumber,
+                            caseId: caseData.caseId,
+                            tryCount,
+                            originalError: error instanceof Error ? error.message : String(error),
+                        }
+                    );
+
+                    await StorageClient.saveCase({
+                        ...caseData,
+                        fetchStatus: {
+                            status: 'failed',
+                            message: 'Persistent summary parsing failure after reprocessing attempt',
+                        },
+                        lastUpdated: new Date().toISOString(),
+                    });
+                    return;
+                }
+
+                // Alert for initial parsing error
+                const AlertService = await import('./AlertService');
+                await AlertService.default.logError(
+                    AlertService.Severity.WARNING,
+                    AlertService.AlertCategory.DATABASE,
+                    'Case summary parsing error detected, attempting reprocessing',
+                    error instanceof Error ? error : new Error(String(error)),
+                    {
+                        caseNumber,
+                        caseId: caseData.caseId,
+                        action: 'reprocessing',
+                        originalError: error instanceof Error ? error.message : String(error),
+                    }
+                );
+
+                await StorageClient.deleteCaseSummary(caseNumber);
+
+                if (caseData.caseId) {
+                    await StorageClient.saveCase({
+                        ...caseData,
+                        fetchStatus: { status: 'reprocessing', tryCount: tryCount + 1 },
+                        lastUpdated: new Date().toISOString(),
+                    });
+
+                    console.log(`Case ${caseNumber} marked for reprocessing due to summary parsing error`);
+                }
+            } catch (cleanupError) {
+                console.error(`Failed to cleanup corrupted summary for case ${caseNumber}:`, cleanupError);
+
+                // Alert on cleanup failure
+                try {
+                    const AlertService = await import('./AlertService');
+                    await AlertService.default.logError(
+                        AlertService.Severity.ERROR,
+                        AlertService.AlertCategory.SYSTEM,
+                        'Failed to cleanup case summary after parsing error',
+                        cleanupError instanceof Error ? cleanupError : new Error(String(cleanupError)),
+                        { caseNumber, caseId: caseData.caseId }
+                    );
+                } catch (alertError) {
+                    console.error('Failed to send cleanup failure alert:', alertError);
+                }
+            }
+        });
+    }
+
+    return summary;
 }
 
 const StorageClient = {
@@ -488,26 +708,50 @@ const StorageClient = {
 
         const results: Record<string, SearchResult> = {};
 
-        caseNumbers.forEach(caseNumber => {
-            const { caseKey, summaryKey } = keyMapping[caseNumber];
-            const caseItem = resultMap.get(caseKey);
+        // Process all cases in parallel, allowing individual failures
+        const caseResults = await Promise.allSettled(
+            caseNumbers.map(async caseNumber => {
+                try {
+                    const { caseKey, summaryKey } = keyMapping[caseNumber];
+                    const caseItem = resultMap.get(caseKey);
 
-            if (!caseItem) {
-                return;
+                    if (!caseItem) {
+                        return null;
+                    }
+
+                    const caseData = caseItem as unknown as ZipCase;
+                    if (!caseData) {
+                        return null;
+                    }
+
+                    const summaryItem = resultMap.get(summaryKey);
+
+                    // Use the dedicated validation function to process the summary
+                    const summary = await validateAndProcessCaseSummary(caseNumber, caseData, summaryItem);
+
+                    return {
+                        caseNumber,
+                        result: {
+                            zipCase: caseData,
+                            caseSummary: summary,
+                        },
+                    };
+                } catch (error) {
+                    console.error(`Error processing case ${caseNumber} in getSearchResults:`, error);
+                    // Return null so this case is excluded from results rather than failing the entire operation
+                    return null;
+                }
+            })
+        );
+
+        // Process the settled results
+        caseResults.forEach(settledResult => {
+            if (settledResult.status === 'fulfilled' && settledResult.value) {
+                const { caseNumber, result } = settledResult.value;
+                results[caseNumber] = result;
+            } else if (settledResult.status === 'rejected') {
+                console.error('Case processing failed:', settledResult.reason);
             }
-
-            const caseData = caseItem as unknown as ZipCase;
-            if (!caseData) {
-                return;
-            }
-
-            const summaryItem = resultMap.get(summaryKey);
-            const summary = summaryItem as unknown as CaseSummary;
-
-            results[caseNumber] = {
-                zipCase: caseData,
-                caseSummary: summary ?? undefined,
-            };
         });
 
         return results;
@@ -520,6 +764,25 @@ const StorageClient = {
 
     async saveCaseSummary(caseNumber: string, caseSummary: CaseSummary): Promise<void> {
         await save(Key.Case(caseNumber).SUMMARY, caseSummary);
+    },
+
+    async deleteCaseSummary(caseNumber: string): Promise<void> {
+        const dynamoClient = DynamoDBDocumentClient.from(new DynamoDBClient({ region: 'us-east-2' }));
+
+        const key = Key.Case(caseNumber).SUMMARY;
+
+        try {
+            await dynamoClient.send(
+                new DynamoDBDeleteCommand({
+                    TableName: process.env.DYNAMODB_TABLE_NAME,
+                    Key: key,
+                })
+            );
+            console.log(`Deleted corrupted summary for case ${caseNumber}`);
+        } catch (error) {
+            console.error(`Failed to delete summary for case ${caseNumber}:`, error);
+            throw error;
+        }
     },
 };
 

--- a/serverless/lib/__tests__/CaseSearchProcessor.test.ts
+++ b/serverless/lib/__tests__/CaseSearchProcessor.test.ts
@@ -196,7 +196,7 @@ describe('CaseSearchProcessor', () => {
             expect(mockQueueClient.queueCaseForDataRetrieval).not.toHaveBeenCalled();
         });
 
-        it('should handle cases with processing status (preserve status, do not re-queue)', async () => {
+        it('should handle cases with processing status (should re-queue for processing)', async () => {
             const processingCase: SearchResult = {
                 zipCase: {
                     caseNumber: '22CR123456-789',
@@ -213,8 +213,8 @@ describe('CaseSearchProcessor', () => {
 
             const result = await processCaseSearchRequest(baseRequest);
 
-            // Should NOT queue for search (processing cases are left alone)
-            expect(mockQueueClient.queueCasesForSearch).not.toHaveBeenCalled();
+            // Should queue for search (processing cases get re-queued in case they're stuck)
+            expect(mockQueueClient.queueCasesForSearch).toHaveBeenCalledWith(['22CR123456-789'], 'test-user-id', 'Test Agent');
             expect(mockQueueClient.queueCaseForDataRetrieval).not.toHaveBeenCalled();
             expect(mockStorageClient.saveCase).not.toHaveBeenCalled();
         });

--- a/serverless/lib/__tests__/storageClient.test.ts
+++ b/serverless/lib/__tests__/storageClient.test.ts
@@ -20,6 +20,7 @@ jest.mock('@aws-sdk/lib-dynamodb', () => ({
     BatchGetCommand: jest.fn().mockImplementation(params => params),
     GetCommand: jest.fn().mockImplementation(params => params),
     PutCommand: jest.fn().mockImplementation(params => params),
+    DeleteCommand: jest.fn().mockImplementation(params => params),
 }));
 
 jest.mock('@aws-sdk/client-kms', () => ({
@@ -28,6 +29,21 @@ jest.mock('@aws-sdk/client-kms', () => ({
     })),
     EncryptCommand: jest.fn().mockImplementation(params => params),
     DecryptCommand: jest.fn().mockImplementation(params => params),
+}));
+
+// Mock the AlertService
+jest.mock('../AlertService', () => ({
+    default: {
+        logError: jest.fn().mockResolvedValue(undefined),
+        Severity: {
+            ERROR: 'ERROR',
+            WARNING: 'WARNING',
+        },
+        AlertCategory: {
+            DATABASE: 'DATABASE',
+            SYSTEM: 'SYSTEM',
+        },
+    },
 }));
 
 describe('StorageClient helpers', () => {
@@ -138,6 +154,272 @@ describe('StorageClient helpers', () => {
                 // Restore the original batch size
                 BatchHelper.BATCH_GET_MAX_ITEMS = originalBatchSize;
             });
+        });
+    });
+});
+
+describe('StorageClient.getSearchResults resilience', () => {
+    // Mock the getMany function to return test data
+    const mockGetMany = jest.fn();
+    const mockSetImmediate = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        // Mock environment variables
+        process.env.ZIPCASE_DATA_TABLE = 'test-table';
+        process.env.DYNAMODB_TABLE_NAME = 'test-table';
+
+        // Mock setImmediate to prevent actual async cleanup during tests
+        jest.spyOn(global, 'setImmediate').mockImplementation(mockSetImmediate);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe('StorageClient.getSearchResults resilience', () => {
+        const mockSetImmediate = jest.fn();
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+
+            // Mock environment variables
+            process.env.ZIPCASE_DATA_TABLE = 'test-table';
+            process.env.DYNAMODB_TABLE_NAME = 'test-table';
+
+            // Mock setImmediate to prevent actual async cleanup during tests
+            jest.spyOn(global, 'setImmediate').mockImplementation(mockSetImmediate);
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('should return valid summary when case data is properly formatted', async () => {
+            const { validateAndProcessCaseSummary } = require('../StorageClient');
+
+            const caseNumber = 'VALID001';
+            const caseData = {
+                caseNumber,
+                caseId: 'valid-case-id',
+                fetchStatus: { status: 'complete' },
+                lastUpdated: '2025-09-19T12:00:00Z',
+            };
+
+            const validSummaryItem = {
+                caseName: 'State vs Valid Defendant',
+                court: 'Test Superior Court',
+                charges: [
+                    { description: 'Charge 1', statute: 'ABC-123' },
+                    { description: 'Charge 2', statute: 'DEF-456' },
+                ],
+            };
+
+            const result = await validateAndProcessCaseSummary(caseNumber, caseData, validSummaryItem);
+
+            expect(result).toEqual(validSummaryItem);
+            expect(mockSetImmediate).not.toHaveBeenCalled(); // No cleanup should be triggered
+        });
+
+        it('should return undefined and trigger cleanup for corrupted summary (missing required fields)', async () => {
+            const { validateAndProcessCaseSummary } = require('../StorageClient');
+
+            const caseNumber = 'CORRUPT001';
+            const caseData = {
+                caseNumber,
+                caseId: 'corrupt-case-id',
+                fetchStatus: { status: 'complete' },
+                lastUpdated: '2025-09-19T12:00:00Z',
+            };
+
+            const corruptedSummaryItem = {
+                // Missing caseName and court - should trigger corruption detection
+                charges: null, // Invalid charges format
+                someRandomField: 'corrupt data',
+            };
+
+            const result = await validateAndProcessCaseSummary(caseNumber, caseData, corruptedSummaryItem);
+
+            expect(result).toBeUndefined();
+            expect(mockSetImmediate).toHaveBeenCalled(); // Cleanup should be scheduled
+        });
+
+        it('should return undefined and trigger cleanup for summary missing caseName', async () => {
+            const { validateAndProcessCaseSummary } = require('../StorageClient');
+
+            const caseNumber = 'MISSING_NAME001';
+            const caseData = {
+                caseNumber,
+                caseId: 'missing-name-case-id',
+                fetchStatus: { status: 'complete' },
+            };
+
+            const summaryMissingName = {
+                // caseName is missing
+                court: 'Test Court',
+                charges: [{ description: 'Valid charge' }],
+            };
+
+            const result = await validateAndProcessCaseSummary(caseNumber, caseData, summaryMissingName);
+
+            expect(result).toBeUndefined();
+            expect(mockSetImmediate).toHaveBeenCalled();
+        });
+
+        it('should return undefined and trigger cleanup for summary missing court', async () => {
+            const { validateAndProcessCaseSummary } = require('../StorageClient');
+
+            const caseNumber = 'MISSING_COURT001';
+            const caseData = {
+                caseNumber,
+                caseId: 'missing-court-case-id',
+                fetchStatus: { status: 'complete' },
+            };
+
+            const summaryMissingCourt = {
+                caseName: 'State vs Defendant',
+                // court is missing
+                charges: [{ description: 'Valid charge' }],
+            };
+
+            const result = await validateAndProcessCaseSummary(caseNumber, caseData, summaryMissingCourt);
+
+            expect(result).toBeUndefined();
+            expect(mockSetImmediate).toHaveBeenCalled();
+        });
+
+        it('should return undefined and trigger cleanup for invalid charges array', async () => {
+            const { validateAndProcessCaseSummary } = require('../StorageClient');
+
+            const caseNumber = 'INVALID_CHARGES001';
+            const caseData = {
+                caseNumber,
+                caseId: 'invalid-charges-case-id',
+                fetchStatus: { status: 'complete' },
+            };
+
+            const summaryInvalidCharges = {
+                caseName: 'State vs Defendant',
+                court: 'Test Court',
+                charges: 'not an array', // Should be an array
+            };
+
+            const result = await validateAndProcessCaseSummary(caseNumber, caseData, summaryInvalidCharges);
+
+            expect(result).toBeUndefined();
+            expect(mockSetImmediate).toHaveBeenCalled();
+        });
+
+        it('should return undefined when summaryItem is undefined', async () => {
+            const { validateAndProcessCaseSummary } = require('../StorageClient');
+
+            const caseNumber = 'NO_SUMMARY001';
+            const caseData = {
+                caseNumber,
+                caseId: 'no-summary-case-id',
+                fetchStatus: { status: 'complete' },
+            };
+
+            const result = await validateAndProcessCaseSummary(caseNumber, caseData, undefined);
+
+            expect(result).toBeUndefined();
+            expect(mockSetImmediate).not.toHaveBeenCalled(); // No cleanup needed for missing summary
+        });
+
+        it('should handle reprocessing attempts and prevent infinite loops', async () => {
+            const { validateAndProcessCaseSummary } = require('../StorageClient');
+
+            const caseNumber = 'REPROCESSING001';
+            const caseDataAlreadyReprocessing = {
+                caseNumber,
+                caseId: 'reprocessing-case-id',
+                fetchStatus: { status: 'reprocessing', tryCount: 1 }, // Already tried once
+            };
+
+            const corruptedSummaryItem = {
+                // Still corrupted after reprocessing
+                charges: null,
+                someField: 'still corrupt',
+            };
+
+            const result = await validateAndProcessCaseSummary(caseNumber, caseDataAlreadyReprocessing, corruptedSummaryItem);
+
+            expect(result).toBeUndefined();
+            expect(mockSetImmediate).toHaveBeenCalled(); // Should still trigger cleanup, but will mark as permanently failed
+        });
+
+        it('should verify Promise.allSettled behavior: getSearchResults handles mixed success/failure gracefully', async () => {
+            // This test verifies that getSearchResults uses Promise.allSettled behavior
+            // by using the exported validation function with mixed inputs
+
+            const { validateAndProcessCaseSummary } = require('../StorageClient');
+
+            // Simulate what getSearchResults does internally: process multiple cases
+            const testCases = [
+                {
+                    caseNumber: 'VALID001',
+                    caseData: { caseNumber: 'VALID001', caseId: 'id1', fetchStatus: { status: 'complete' } },
+                    summaryItem: { caseName: 'Valid Case 1', court: 'Court 1', charges: [{ description: 'Charge 1' }] },
+                    expectedResult: { caseName: 'Valid Case 1', court: 'Court 1', charges: [{ description: 'Charge 1' }] },
+                },
+                {
+                    caseNumber: 'CORRUPT002',
+                    caseData: { caseNumber: 'CORRUPT002', caseId: 'id2', fetchStatus: { status: 'complete' } },
+                    summaryItem: { charges: null }, // Missing caseName and court
+                    expectedResult: undefined,
+                },
+                {
+                    caseNumber: 'VALID003',
+                    caseData: { caseNumber: 'VALID003', caseId: 'id3', fetchStatus: { status: 'complete' } },
+                    summaryItem: { caseName: 'Valid Case 3', court: 'Court 3', charges: [{ description: 'Charge 3' }] },
+                    expectedResult: { caseName: 'Valid Case 3', court: 'Court 3', charges: [{ description: 'Charge 3' }] },
+                },
+            ];
+
+            // Process all cases using Promise.allSettled (same pattern as getSearchResults)
+            const results = await Promise.allSettled(
+                testCases.map(async testCase => {
+                    try {
+                        const summary = await validateAndProcessCaseSummary(testCase.caseNumber, testCase.caseData, testCase.summaryItem);
+                        return {
+                            caseNumber: testCase.caseNumber,
+                            success: true,
+                            summary,
+                        };
+                    } catch (error) {
+                        return {
+                            caseNumber: testCase.caseNumber,
+                            success: false,
+                            error,
+                        };
+                    }
+                })
+            );
+
+            // Verify all promises settled (none rejected the entire operation)
+            expect(results).toHaveLength(3);
+            results.forEach(result => {
+                expect(result.status).toBe('fulfilled');
+            });
+
+            // Verify individual case results
+            const [result1, result2, result3] = results.map(r => (r.status === 'fulfilled' ? r.value : null));
+
+            expect(result1?.caseNumber).toBe('VALID001');
+            expect(result1?.success).toBe(true);
+            expect(result1?.summary).toEqual(testCases[0].expectedResult);
+
+            expect(result2?.caseNumber).toBe('CORRUPT002');
+            expect(result2?.success).toBe(true); // Function completed successfully
+            expect(result2?.summary).toBeUndefined(); // But summary is undefined due to corruption
+
+            expect(result3?.caseNumber).toBe('VALID003');
+            expect(result3?.success).toBe(true);
+            expect(result3?.summary).toEqual(testCases[2].expectedResult);
+
+            // Verify cleanup was triggered for the corrupted case only
+            expect(mockSetImmediate).toHaveBeenCalled();
         });
     });
 });

--- a/shared/types/ZipCase.ts
+++ b/shared/types/ZipCase.ts
@@ -4,6 +4,7 @@ export type FetchStatus =
     | { status: 'found' } // New status - caseId exists but case data not yet fetched
     | { status: 'notFound' }
     | { status: 'processing' }
+    | { status: 'reprocessing'; tryCount: number }
     | { status: 'queued' };
 
 export interface ChargeDegree {


### PR DESCRIPTION
- Make `notFound` a non-terminal status, since Portal sometimes fails to "find" a case
- Queue `processing` cases when requested, in case they are stuck in that status
- Delete and requeue case summaries when those summaries can't be parsed; raise an alert