### PR TITLE
#129 bump xlsx to 0.20.3 from SheetJS CDN instead of npm

### DIFF
--- a/serverless/package-lock.json
+++ b/serverless/package-lock.json
@@ -18,7 +18,7 @@
                 "cheerio": "^1.0.0",
                 "humanparser": "^2.7.0",
                 "tough-cookie": "^5.1.2",
-                "xlsx": "^0.18.5"
+                "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
             },
             "devDependencies": {
                 "@eslint/js": "^9.24.0",
@@ -10159,15 +10159,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/adler-32": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-            "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/agent-base": {
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -10772,19 +10763,6 @@
             ],
             "license": "CC-BY-4.0"
         },
-        "node_modules/cfb": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-            "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "adler-32": "~1.3.0",
-                "crc-32": "~1.2.0"
-            },
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/chalk": {
             "version": "5.4.1",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
@@ -10897,15 +10875,6 @@
                 "node": ">= 0.12.0"
             }
         },
-        "node_modules/codepage": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-            "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/collect-v8-coverage": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -10965,18 +10934,6 @@
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/crc-32": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-            "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-            "license": "Apache-2.0",
-            "bin": {
-                "crc32": "bin/crc32.njs"
-            },
-            "engines": {
-                "node": ">=0.8"
-            }
         },
         "node_modules/create-jest": {
             "version": "29.7.0",
@@ -12109,15 +12066,6 @@
             },
             "engines": {
                 "node": ">=12.20.0"
-            }
-        },
-        "node_modules/frac": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-            "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=0.8"
             }
         },
         "node_modules/fs-extra": {
@@ -16215,18 +16163,6 @@
             "dev": true,
             "license": "BSD-3-Clause"
         },
-        "node_modules/ssf": {
-            "version": "0.11.2",
-            "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-            "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "frac": "~1.1.2"
-            },
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/stack-utils": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -17023,24 +16959,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/wmf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-            "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
-        "node_modules/word": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-            "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/word-wrap": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -17205,19 +17123,10 @@
             }
         },
         "node_modules/xlsx": {
-            "version": "0.18.5",
-            "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-            "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+            "version": "0.20.3",
+            "resolved": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+            "integrity": "sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==",
             "license": "Apache-2.0",
-            "dependencies": {
-                "adler-32": "~1.3.0",
-                "cfb": "~1.2.1",
-                "codepage": "~1.15.0",
-                "crc-32": "~1.2.1",
-                "ssf": "~0.11.2",
-                "wmf": "~1.0.1",
-                "word": "~0.3.0"
-            },
             "bin": {
                 "xlsx": "bin/xlsx.njs"
             },

--- a/serverless/package.json
+++ b/serverless/package.json
@@ -30,7 +30,7 @@
         "cheerio": "^1.0.0",
         "humanparser": "^2.7.0",
         "tough-cookie": "^5.1.2",
-        "xlsx": "^0.18.5"
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
     },
     "scripts": {
         "test": "jest",


### PR DESCRIPTION
Addresses these dependabot alerts:
- https://github.com/CodeWithAsheville/zipcase/security/dependabot/38
- https://github.com/CodeWithAsheville/zipcase/security/dependabot/39